### PR TITLE
Added new use case, testing markdown table syntax

### DIFF
--- a/Deliverables/Use Cases/use_case1.md
+++ b/Deliverables/Use Cases/use_case1.md
@@ -14,14 +14,14 @@ Users use this use case to allocate task to themselves.
 This use case is for users to take on unallocated tasks. Any task that is either new or has been released by another user is considered unallocated.
 
 ## Related Use Cases
-Specialization of: Allocate Task **//Do we need hierchies?** testing
+Specialization of: Allocate Task **//Do we need hierarchies?** testing
 
 ## Steps
-### Actor Action		|		System Responses
---------------			|		----------------
-1. Choose a task 		|		Confirmation dialog appears
-1. Confirm allocation	|		Confirmation dialog dissapears
+| Actor Action | System Responses |
+| --- | --- |
+| Choose a task | Confirmation dialog appears |
+| Confirm allocation | Confirmation dialog disappears |
 
-## Postconditions
+## Post-conditions
 * The unallocated task is now allocated.
-* The the formally unallocated task is now allocated to the user.
+* The formally unallocated task is now allocated to the user.

--- a/Deliverables/Use Cases/use_case2.md
+++ b/Deliverables/Use Cases/use_case2.md
@@ -1,0 +1,31 @@
+# Name: Create New Account
+
+## Actors
+* Adult
+
+## Goals
+Create a new Adult or Child account
+
+## Preconditions:
+* If an Adult account exists in the app, the user must be logged into it.
+* If no accounts exist, the user will be prompted to create a new Adult account.
+
+## Summary
+This use case allows an Adult to create an account for either another or a child. The adult has elevated privileges that allow them to do so. This ensures control of the app is left in the hands of the adult.
+
+## Related Use Cases
+Set up app (If no accounts exist)
+
+## Steps
+| Actor Action | System Responses |
+| --- | --- |
+|  | If no accounts exist, prompt user to set up app |
+| Choose "Create Account" from settings menu | Screen changes to display input fields for new account |
+| User enters Name and chooses privilege level (Adult/Child) |  |
+| User confirms information by tapping "Okay" button at bottom of screen | Toast informing the user the account has been created |
+| | Screen changes back to default task list |
+
+## Post-conditions
+* The account will now be available to choose when assigning tasks
+* The account will now appear on the switch user screen
+* The user will now be on the main task list screen.


### PR DESCRIPTION
Discovered github has really nice syntax if we're making tables, check it out [here.](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)

Also fixed some minor spelling errors and the table formatting in the other use case.